### PR TITLE
always use the latest sanctuary release

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "ramda": "^0.21.0",
     "ramda-fantasy": "^0.4.1",
-    "sanctuary": "^0.10.0"
+    "sanctuary": "*"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",


### PR DESCRIPTION
Since this dependency is only used to evaluate input, it seems reasonable to always require the latest sanctuary version. If you'd prefer to keep the dependency pinned I'll open a new pull request to update the version to `0.11.x`.
